### PR TITLE
Implemented read-out of trace files for custom sample lengths

### DIFF
--- a/focpa.cpp
+++ b/focpa.cpp
@@ -50,6 +50,7 @@ int first_order(Config & conf)
       nmat = conf.n_file_trace,
       nrows = conf.total_n_traces,
       ncol = min(get_ncol<TypeTrace>(memory-(nrows*n_keys*sizeof(TypeGuess)), nrows), n_samples),
+	  word_length = conf.word_length,
       col_incr = ncol,
       col_offset = 0,
       row_offset = 0,
@@ -201,7 +202,7 @@ int first_order(Config & conf)
           cur_n_rows = conf.traces[i].n_rows;
           cur_n_cols = conf.traces[i].n_columns;
 
-          res = load_file_v_1(conf.traces[i].filename, &tmp, cur_n_rows, to_load, conf.index_sample + sample_offset + row_offset, cur_n_cols);
+          res = load_file_v_1(conf.traces[i].filename, &tmp, cur_n_rows, to_load, conf.index_sample + sample_offset + row_offset, cur_n_cols, word_length);
           if (res != 0) {
             fprintf (stderr, "[ERROR] Loading file.\n");
             return -1;

--- a/socpa.cpp
+++ b/socpa.cpp
@@ -45,6 +45,7 @@ int second_order(Config & conf)
       nmat = conf.n_file_trace,
       nrows = conf.total_n_traces,
       window = conf.window,
+	  word_length = conf.word_length,
       ncol = min(\
         get_ncol<TypeReturn>(conf.memory -(nrows*n_keys*sizeof(TypeGuess)), nrows),\
         n_samples),
@@ -198,7 +199,7 @@ int second_order(Config & conf)
         cur_n_rows = conf.traces[i].n_rows;
         cur_n_cols = conf.traces[i].n_columns;
 
-        res = load_file_v_1(conf.traces[i].filename, &tmp, cur_n_rows, to_load, conf.index_sample + sample_offset + row_offset, cur_n_cols);
+        res = load_file_v_1(conf.traces[i].filename, &tmp, cur_n_rows, to_load, conf.index_sample + sample_offset + row_offset, cur_n_cols, word_length);
         if (res != 0) {
           fprintf (stderr, "[ERROR] loading file.\n");
           return -1;

--- a/utils.cpp
+++ b/utils.cpp
@@ -303,7 +303,7 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
   int i, res;
   long int offset_byte = floor((offset * word_length) / 8);
   int offset_bit = (offset * word_length) % 8;
-  char current_byte = NULL;
+  char current_byte = 0;
 
   if (n_columns <= 0){
     fprintf (stderr, "Error: Invalid parameters: n_columns <= 0.\n");
@@ -362,7 +362,7 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
       }
     } else {
       for (int col = 0; col < n_columns; col++) {
-        Type sample = 0;
+        int sample = 0;
         for (int b = 0; b < word_length; b++) {
           if (offset_bit > 7) {
             current_byte = fgetc(file);
@@ -373,7 +373,7 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
             sample |= (1 << b);
           offset_bit++;
         }
-        (*mem)[i] = sample;
+        (*mem)[i][col] = (Type) sample;
       }
     }
 
@@ -857,22 +857,22 @@ int load_config(Config & config, const char * conf_file)
         config.word_length = atoi(line.substr(line.find("=") + 1).c_str());
         // verify whether words of this length fit into the trace type that was given
         int orig_sample_size;
-        if (type_trace == "f") {
+        if (config.type_trace == "f") {
             orig_sample_size = sizeof(float);
-        } else if (type_trace == "u") {
+        } else if (config.type_trace == "u") {
             orig_sample_size = sizeof(uint8_t);
-        } else if (trace_type == "d") {
+        } else if (config.type_trace == "d") {
             orig_sample_size = sizeof(double);
-        } else if (trace_type == "i") {
+        } else if (config.type_trace == "i") {
             orig_sample_size = sizeof(int8_t);
         }
         if (config.word_length > orig_sample_size * 8) {
-            printf(stderr, "Error: Word length is too large for the trace type. %d was chosen.\n", word_length);
+            printf(stderr, "Error: Word length is too large for the trace type. %d was chosen.\n", config.word_length);
             return -1;
         }
         // Divide the number of samples by the word length such that the dimensions of the matrices
         // in the CPA attack are still fine.
-        config.n_samples = (orig_sample_size * n_samples) / config.word_length;
+        config.n_samples = (orig_sample_size * config.n_samples) / config.word_length;
         tot_col_traces = (orig_sample_size * tot_col_traces) / config.word_length;
         tot_col_guesses = (orig_sample_size * tot_col_guesses) / config.word_length;
       }

--- a/utils.cpp
+++ b/utils.cpp
@@ -297,7 +297,7 @@ int load_file_v_2(const char str[], Type *** mem, int n_rows, int n_columns, lon
 /* Like load_file but doens't allocate new memory each time.
  */
   template <class Type>
-int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, long int offset, int total_n_columns)
+int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, long int offset, int total_n_columns, int word_length)
 {
   FILE * file = NULL;
   int i, res;
@@ -645,6 +645,7 @@ int load_config(Config & config, const char * conf_file)
   config.bitnum = -2;
   config.complete_correct_key = NULL;
   config.original_correct_key = NULL;
+  config.word_length = 1;
 
   while (getline(fin, line)) {
     if (line[0] == '#'){
@@ -813,7 +814,9 @@ int load_config(Config & config, const char * conf_file)
       }
       //printf("%s %li %f\n", tmp.c_str(), tmp.size(), atof(tmp.substr(0, tmp.size() - 1).c_str()));
       config.memory = (long int)(atof(tmp.substr(0, tmp.size() - 1).c_str())*suffix);
-    }
+    } else if (line.find("word_length") != string::npos) {
+      config.word_length = atoi(line.substr(line.find("=") + 1).c_str());
+	}
 
   }
 
@@ -974,7 +977,7 @@ void print_config(Config &conf)
   else if(conf.memory > MEGA)
     printf("\tMemory:\t\t\t %.2fMB\n", conf.memory/MEGA);
   printf("\tKeep track of:\t\t %i\n", conf.top);
-
+  printf("\tWord length:\t\t %i\n", conf.word_length);
 
   if (conf.sep == "") printf("\tSeparator :\t\t STANDARD\n");
   else printf("\tSeparator :\t\t %s\n", conf.sep.c_str());
@@ -1036,11 +1039,11 @@ template int import_matrices(uint8_t *** mem, Matrix * matrices, unsigned int n_
 template size_t fload(const char str[], float *** mem, int chunk_size, long int chunk_offset, int n_columns, long int col_offset, int tot_n_cols);
 template size_t fload(const char str[], int8_t *** mem, int chunk_size, long int chunk_offset, int n_columns, long int col_offset, int tot_n_cols);
 
-template int load_file_v_1(const char str[], float *** mem, int n_rows, int n_columns, long int offset, int total_n_columns);
-template int load_file_v_1(const char str[], double *** mem, int n_rows, int n_columns, long int offset, int total_n_columns);
-template int load_file_v_1(const char str[], int8_t *** mem, int n_rows, int n_columns, long int offset, int total_n_columns);
-template int load_file_v_1(const char str[], uint8_t *** mem, int n_rows, int n_columns, long int offset, int total_n_columns);
-template int load_file_v_1(const char str[], int *** mem, int n_rows, int n_columns, long int offset, int total_n_columns);
+template int load_file_v_1(const char str[], float *** mem, int n_rows, int n_columns, long int offset, int total_n_columns, int word_length);
+template int load_file_v_1(const char str[], double *** mem, int n_rows, int n_columns, long int offset, int total_n_columns, int word_length);
+template int load_file_v_1(const char str[], int8_t *** mem, int n_rows, int n_columns, long int offset, int total_n_columns, int word_length);
+template int load_file_v_1(const char str[], uint8_t *** mem, int n_rows, int n_columns, long int offset, int total_n_columns, int word_length);
+template int load_file_v_1(const char str[], int *** mem, int n_rows, int n_columns, long int offset, int total_n_columns, int word_length);
 
 template int load_file(const char str[], float *** mem, int n_rows, int n_columns, long int offset, int total_n_columns);
 template int load_file(const char str[], double *** mem, int n_rows, int n_columns, long int offset, int total_n_columns);

--- a/utils.cpp
+++ b/utils.cpp
@@ -301,6 +301,9 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
 {
   FILE * file = NULL;
   int i, res;
+  long int offset_byte = floor((offset * word_length) / 8);
+  int offset_bit = (offset * word_length) % 8;
+  char current_byte = NULL;
 
   if (n_columns <= 0){
     fprintf (stderr, "Error: Invalid parameters: n_columns <= 0.\n");
@@ -332,7 +335,13 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
   }
 
   //res = fseek(file, offset, SEEK_SET);
-  res = fseek(file, offset*sizeof(Type), SEEK_CUR);
+  // Move filepointer to the position of the sample at the given offset
+  if (word_length == -1) { // use default
+    res = fseek(file, offset*sizeof(Type), SEEK_CUR);
+  } else {
+    res = fseek(file, offset_byte, SEEK_CUR);
+    current_byte = fgetc(file);
+  }
   if (res != 0) {
     fprintf (stderr, "Error: fseek != 0 when reading file %s\n", str);
     return -1;
@@ -344,19 +353,44 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
       return -1;
     }
 
-    res = fread ((*mem)[i], sizeof(Type), n_columns, file);
-    //res = fread ((*mem + i), sizeof(Type), n_columns, file);
-    if (res < n_columns) {
-      fprintf (stderr, "Error: fread < 0 when reading file %s\n", str);
-      return -1;
+    // Read the requested columns into mem
+    if (word_length == -1) {
+      res = fread ((*mem)[i], sizeof(Type), n_columns, file);
+      if (res < n_columns) {
+        fprintf (stderr, "Error: fread < 0 when reading file %s\n", str);
+        return -1;
+      }
+    } else {
+      for (int col = 0; col < n_columns; col++) {
+        Type sample = 0;
+        for (int b = 0; b < word_length; b++) {
+          if (offset_bit > 7) {
+            current_byte = fgetc(file);
+            offset_bit = 0;
+          }
+          int bit = ((current_byte >> (7-offset_bit)) & 1);
+          if (bit == 1)
+            sample |= (1 << b);
+          offset_bit++;
+        }
+        (*mem)[i] = sample;
+      }
     }
 
     /* Used when importing a subset of the time samples.
      */
-    res = fseek(file, (total_n_columns - n_columns)*sizeof(Type), SEEK_CUR);
-    if (res != 0) {
-      fprintf (stderr, "Error: fseek != 0 when reading file %s\n", str);
-      return -1;
+    if (word_length == -1) {
+      res = fseek(file, (total_n_columns - n_columns)*sizeof(Type), SEEK_CUR);
+      if (res != 0) {
+        fprintf (stderr, "Error: fseek != 0 when reading file %s\n", str);
+        return -1;
+      }
+    } else {
+      res = fseek(file, floor((total_n_columns - n_columns)*word_length/8), SEEK_CUR);
+      if (res != 0) {
+        fprintf (stderr, "Error: fseek != 0 when reading file %s\n", str);
+        return -1;
+      }
     }
   }
 
@@ -645,7 +679,7 @@ int load_config(Config & config, const char * conf_file)
   config.bitnum = -2;
   config.complete_correct_key = NULL;
   config.original_correct_key = NULL;
-  config.word_length = 1;
+  config.word_length = -1;
 
   while (getline(fin, line)) {
     if (line[0] == '#'){
@@ -816,7 +850,33 @@ int load_config(Config & config, const char * conf_file)
       config.memory = (long int)(atof(tmp.substr(0, tmp.size() - 1).c_str())*suffix);
     } else if (line.find("word_length") != string::npos) {
       config.word_length = atoi(line.substr(line.find("=") + 1).c_str());
-	}
+      string tmp = line.substr(line.find("=") + 1);
+      if (!tmp.compare("default")) {
+        config.word_length = -1;
+      } else {
+        config.word_length = atoi(line.substr(line.find("=") + 1).c_str());
+        // verify whether words of this length fit into the trace type that was given
+        int orig_sample_size;
+        if (type_trace == "f") {
+            orig_sample_size = sizeof(float);
+        } else if (type_trace == "u") {
+            orig_sample_size = sizeof(uint8_t);
+        } else if (trace_type == "d") {
+            orig_sample_size = sizeof(double);
+        } else if (trace_type == "i") {
+            orig_sample_size = sizeof(int8_t);
+        }
+        if (config.word_length > orig_sample_size * 8) {
+            printf(stderr, "Error: Word length is too large for the trace type. %d was chosen.\n", word_length);
+            return -1;
+        }
+        // Divide the number of samples by the word length such that the dimensions of the matrices
+        // in the CPA attack are still fine.
+        config.n_samples = (orig_sample_size * n_samples) / config.word_length;
+        tot_col_traces = (orig_sample_size * tot_col_traces) / config.word_length;
+        tot_col_guesses = (orig_sample_size * tot_col_guesses) / config.word_length;
+      }
+    }
 
   }
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -856,14 +856,14 @@ int load_config(Config & config, const char * conf_file)
       } else {
         config.word_length = atoi(line.substr(line.find("=") + 1).c_str());
         // verify whether words of this length fit into the trace type that was given
-        int orig_sample_size;
-        if (strcmp(config.type_trace, 'f') == 0) {
+        int orig_sample_size = 0;
+        if (config.type_trace == 'f') {
             orig_sample_size = sizeof(float);
-        } else if (strcmp(config.type_trace, 'u') == 0) {
+        } else if (config.type_trace == 'u') {
             orig_sample_size = sizeof(uint8_t);
-        } else if (strcmp(config.type_trace, 'd') == 0) {
+        } else if (config.type_trace == 'd') {
             orig_sample_size = sizeof(double);
-        } else if (strcmp(config.type_trace, 'i') == 0) {
+        } else if (config.type_trace == 'i') {
             orig_sample_size = sizeof(int8_t);
         }
         if (config.word_length > orig_sample_size * 8) {

--- a/utils.cpp
+++ b/utils.cpp
@@ -985,6 +985,7 @@ void print_config(Config &conf)
   printf("\tTotal number traces:\t %i\n", conf.total_n_traces);
   printf("\tTarget number traces:\t %i\n", conf.n_traces);
   printf("\tTotal number keys:\t %i\n", conf.total_n_keys);
+  printf("\tWord length:\t\t %i\n", conf.word_length);
 
   printf("\tAttack order:\t\t %i\n", conf.attack_order);
 
@@ -1036,7 +1037,6 @@ void print_config(Config &conf)
   else if(conf.memory > MEGA)
     printf("\tMemory:\t\t\t %.2fMB\n", conf.memory/MEGA);
   printf("\tKeep track of:\t\t %i\n", conf.top);
-  printf("\tWord length:\t\t %i\n", conf.word_length);
 
   if (conf.sep == "") printf("\tSeparator :\t\t STANDARD\n");
   else printf("\tSeparator :\t\t %s\n", conf.sep.c_str());

--- a/utils.cpp
+++ b/utils.cpp
@@ -303,7 +303,7 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
   int i, res;
   long int offset_byte = floor((offset * word_length) / 8);
   int offset_bit = (offset * word_length) % 8;
-  char current_byte = NULL;
+  char current_byte = 0;
 
   if (n_columns <= 0){
     fprintf (stderr, "Error: Invalid parameters: n_columns <= 0.\n");
@@ -362,7 +362,7 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
       }
     } else {
       for (int col = 0; col < n_columns; col++) {
-        Type sample = 0;
+        int sample = 0;
         for (int b = 0; b < word_length; b++) {
           if (offset_bit > 7) {
             current_byte = fgetc(file);
@@ -373,7 +373,7 @@ int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, lon
             sample |= (1 << b);
           offset_bit++;
         }
-        (*mem)[i] = sample;
+        (*mem)[i][col] = (Type) sample;
       }
     }
 
@@ -857,22 +857,22 @@ int load_config(Config & config, const char * conf_file)
         config.word_length = atoi(line.substr(line.find("=") + 1).c_str());
         // verify whether words of this length fit into the trace type that was given
         int orig_sample_size;
-        if (type_trace == "f") {
+        if (strcmp(config.type_trace, 'f') == 0) {
             orig_sample_size = sizeof(float);
-        } else if (type_trace == "u") {
+        } else if (strcmp(config.type_trace, 'u') == 0) {
             orig_sample_size = sizeof(uint8_t);
-        } else if (trace_type == "d") {
+        } else if (strcmp(config.type_trace, 'd') == 0) {
             orig_sample_size = sizeof(double);
-        } else if (trace_type == "i") {
+        } else if (strcmp(config.type_trace, 'i') == 0) {
             orig_sample_size = sizeof(int8_t);
         }
         if (config.word_length > orig_sample_size * 8) {
-            printf(stderr, "Error: Word length is too large for the trace type. %d was chosen.\n", word_length);
+            fprintf(stderr, "Error: Word length is too large for the trace type. %d was chosen.\n", config.word_length);
             return -1;
         }
         // Divide the number of samples by the word length such that the dimensions of the matrices
         // in the CPA attack are still fine.
-        config.n_samples = (orig_sample_size * n_samples) / config.word_length;
+        config.n_samples = (orig_sample_size * config.n_samples) / config.word_length;
         tot_col_traces = (orig_sample_size * tot_col_traces) / config.word_length;
         tot_col_guesses = (orig_sample_size * tot_col_guesses) / config.word_length;
       }

--- a/utils.h
+++ b/utils.h
@@ -436,8 +436,11 @@ struct Config {
    */
   int8_t bitnum;
   
-  /* The number of bits that we want to consider as a word for 
-   * the traces.
+  /* The number of bits that we want to consider as a word for the traces.
+   * The number of samples in n_samples must not be altered upon changing the word length
+   * in the configuration file since this is already accounted for.
+   *
+   * "default" = use type_trace defined length
    */
   int word_length;
 

--- a/utils.h
+++ b/utils.h
@@ -435,6 +435,11 @@ struct Config {
    * -1 = all
    */
   int8_t bitnum;
+  
+  /* The number of bits that we want to consider as a word for 
+   * the traces.
+   */
+  int word_length;
 
 };
 
@@ -520,7 +525,7 @@ size_t fload(const char str[], Type *** mem, int chunk_size, long int chunk_offs
   /* Like load_file but doens't allocate new memory each time.
    */
   template <class Type>
-int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, long int offset, int total_n_columns);
+int load_file_v_1(const char str[], Type *** mem, int n_rows, int n_columns, long int offset, int total_n_columns, int word_length);
 
 /* Loads the file located at str in the 2D array mem, whose dimensions
  * are specified by n_rows and n_columns


### PR DESCRIPTION
The functionality was added to define in the configuration the length of a sample (a word) in the trace file. This gives the functionality of compressing or expanding the traces before they are fed into the attack.

To make use of the added functionality, you need to add to the `.config` file in the General section a line `word_length=x` where `x` is the desired length of a sample. This value can range from 1 (a single bit) to `sizeof(trace_type)`. The setting for the number of samples (`nsamples`) should not be adapted as the added functionality adjusts this based on the value for `word_length`. This allows users to tweak `word_length` easily without repeatedly recalculating `nsamples`.